### PR TITLE
Update code to work with Python 3

### DIFF
--- a/chinad/dga.py
+++ b/chinad/dga.py
@@ -17,7 +17,8 @@ def dga(date):
                 chr(date.day),
                 chr(nr)) + 12*"\x00" 
 
-        h = hashlib.sha1(data).digest()
+        h = hashlib.sha1(data.encode('latin1')).digest()
+        h = ''.join(map(chr, h))
         h_le = []
         for i in range(5):
             for j in range(4):

--- a/dircrypt/dga.py
+++ b/dircrypt/dga.py
@@ -2,14 +2,14 @@ import argparse
 
 class RandInt:
 
-    def __init__(self, seed): 
+    def __init__(self, seed):
         self.seed = seed
 
     def rand_int_modulus(self, modulus):
-        ix = self.seed                
-        ix = 16807*(ix % 127773) - 2836*(ix / 127773) & 0xFFFFFFFF        
+        ix = self.seed
+        ix = 16807*(ix % 127773) - 2836*(ix // 127773) & 0xFFFFFFFF
         self.seed = ix
-        return ix % modulus 
+        return ix % modulus
 
 def get_domains(seed, nr):
     r = RandInt(seed)

--- a/gozi/dga.py
+++ b/gozi/dga.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--date", 
             help="date for which to generate domains")
     parser.add_argument("-w", "--wordlist", help="wordlist", 
-            choices=seeds.keys(), default='luther')
+            choices=list(seeds.keys()), default='luther')
     args = parser.parse_args()
     if args.date:
         d = datetime.strptime(args.date, "%Y-%m-%d")

--- a/locky/dgav2.py
+++ b/locky/dgav2.py
@@ -116,7 +116,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-d", "--date", 
             help="date for which to generate domains")
-    parser.add_argument("-c", "--config", choices=range(1,8),
+    parser.add_argument("-c", "--config", choices=list(range(1,8)),
             help="config nr", type=int, default=1)
     args = parser.parse_args()
 

--- a/locky/dgav3.py
+++ b/locky/dgav3.py
@@ -231,7 +231,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-d", "--date", 
             help="date for which to generate domains")
-    parser.add_argument("-c", "--config", choices=range(1,len(config)+1),
+    parser.add_argument("-c", "--config", choices=list(range(1,len(config)+1)),
             help="config nr", type=int, default=1)
     args = parser.parse_args()
 

--- a/murofet/v1/dga.py
+++ b/murofet/v1/dga.py
@@ -20,13 +20,13 @@ def dga(date):
             seed_str += chr((seed[i]))
 
         m = hashlib.md5()
-        m.update(seed_str)
+        m.update(seed_str.encode('latin1'))
         md5 = m.digest()
 
         domain = ""
         for m in md5:
-            d = (ord(m) & 0x1F) + ord('a')
-            c = (ord(m) >> 3) + ord('a')
+            d = (m & 0x1F) + ord('a')
+            c = (m >> 3) + ord('a')
             if d != c:
                 if d <= ord('z'):
                     domain += chr(d)

--- a/murofet/v2/dga.py
+++ b/murofet/v2/dga.py
@@ -22,12 +22,12 @@ def dga(date, key):
             seed_str += chr((seed[i] ^ k))
 
         m = hashlib.md5()
-        m.update(seed_str)
+        m.update(seed_str.encode('latin1'))
         md5 = m.digest()
 
         domain = ""
         for m in md5:
-            tmp = (ord(m) & 0xF) + (ord(m) >> 4) + ord('a')
+            tmp = (m & 0xF) + (m >> 4) + ord('a')
             if tmp <= ord('z'):
                 domain += chr(tmp)
 

--- a/murofet/v3/dga.py
+++ b/murofet/v3/dga.py
@@ -17,7 +17,7 @@ def dga(date):
 
         seed_str = ''.join([chr(s) for s in seed])
 
-        md5 = hashlib.md5(seed_str).digest()
+        md5 = hashlib.md5(seed_str.encode('latin1')).digest()
 
         domain = ""
         for m in md5:
@@ -26,7 +26,6 @@ def dga(date):
                 b:   'q' ... 'z' . '1' ... '6' 
                 c:   '0' ... '9' IFF b is a number, else discard
             """
-            m = ord(m)
             a = (m & 0xF) + ord('a') 
             b = (m >> 4) + ord('q') 
             if b > ord('z'): 

--- a/newgoz/dga.py
+++ b/newgoz/dga.py
@@ -12,11 +12,11 @@ def get_seed(seq_nr, date):
     m = hashlib.md5()
     m.update(seq_nr)
     m.update(year)
-    m.update(key)
+    m.update(key.encode('latin1'))
     m.update(month)
-    m.update(key)
+    m.update(key.encode('latin1'))
     m.update(day)
-    m.update(key)
+    m.update(key.encode('latin1'))
     return m.hexdigest()
 
 def create_domain(seq_nr, date):
@@ -24,7 +24,7 @@ def create_domain(seq_nr, date):
         part = [] 
         for i in range(nr-1):
             edx = seed % 36
-            seed /= 36
+            seed //= 36
             if edx > 9:
                 char = chr(ord('a') + (edx-10))
             else:

--- a/pushdo/dga.py
+++ b/pushdo/dga.py
@@ -108,7 +108,7 @@ def generate_domains(date, config):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="gozi dga")
-    parser.add_argument("-c", "--config", default="kz_v1", choices=configs.keys())
+    parser.add_argument("-c", "--config", default="kz_v1", choices=list(configs.keys()))
     parser.add_argument("-d", "--date", 
             help="date for which to generate domains")
     args = parser.parse_args()

--- a/ramdo/dga.py
+++ b/ramdo/dga.py
@@ -2,7 +2,7 @@ def dga(seed, nr):
     s = (2 * seed * (nr + 1))
     r = s ^ (26 * seed * nr)
     domain = ""
-    for i in xrange(16):
+    for i in range(16):
         r = r & 0xFFFFFFFF
         domain += chr(r % 26 + ord('a'))
         r += (r ^ (s*i**2*26))

--- a/sisron/dga.py
+++ b/sisron/dga.py
@@ -3,10 +3,11 @@ import base64
 import argparse 
 
 def dga(d, day_index, tld_index):
-    tlds = [".com", ".org", ".net", ".info"]
+    tlds = [x.encode('ascii') for x in [".com", ".org", ".net", ".info"]]
     d -= timedelta(days=day_index)
-    ds = d.strftime("%d%m%Y")
-    return base64.b64encode(ds).lower().replace("=","a") + tlds[tld_index]
+    ds = d.strftime("%d%m%Y").encode('latin1')
+    domain = base64.b64encode(ds).lower().replace(b"=",b"a") + tlds[tld_index]
+    return domain.decode('latin1')
 
 if __name__=="__main__":
     parser = argparse.ArgumentParser()

--- a/tinba/dga.py
+++ b/tinba/dga.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 
 
 def dga(seed, domain, tlds, num_domains):


### PR DESCRIPTION
Given Python 2 has hit the end of life, we should update code to Python 3. This PR changes all the DGA generators to run correctly, and yield identical output, with Python 3. I also cleaned up some trailing whitespace in lines that I Needed to change.